### PR TITLE
fix multiple game loops, event listeners, reset time during restart o…

### DIFF
--- a/src/js/controllers/level-controller.js
+++ b/src/js/controllers/level-controller.js
@@ -79,6 +79,9 @@ export function startLevel(levelNumber, DOM) {
 
   DOM.levelDisplay.textContent = levelNumber;
   console.log(`Level ${levelNumber} loaded: ${currentBricks.length} bricks`);
+
+  // Reset mode so Space can start the game again
+  gameState.setMode("READY");
   enterGameMode();
 }
 

--- a/src/js/core/game-engine.js
+++ b/src/js/core/game-engine.js
@@ -2,19 +2,33 @@ import { initInput } from "../systems/inputs.js";
 import { startLoop } from "./loop.js";
 import { gameState, createGameState } from "./state.js";
 
+let inputInitialized = false;
+
 export function startGame(DOM = null) {
   // initialize state from current level (DOM passed from caller)
   createGameState(DOM);
   gameState.setMode("RUNNING");
 
-  initInput();
+  if (!inputInitialized) {
+    initInput();
+    inputInitialized = true;
+  }
   startLoop();
 }
 
+let enterGameModeRegistered = false;
+
 export function enterGameMode(DOM = null) {
+  if (enterGameModeRegistered) return;
+  enterGameModeRegistered = true;
+
   window.addEventListener("keydown", (e) => {
     if (e.code === "Space") {
-      startGame(DOM);
+      const mode = gameState.getMode();
+      // Only start the game if it hasn't been started yet
+      if (mode !== "RUNNING" && mode !== "PAUSED") {
+        startGame(DOM);
+      }
     }
   });
 }

--- a/src/js/core/loop.js
+++ b/src/js/core/loop.js
@@ -3,15 +3,24 @@ import { render } from "../systems/render.js";
 import { gameState } from "./state.js";
 
 let lastTime;
+let loopId = 0; // incremented each startLoop; stale loops exit
 
 export function startLoop() {
+  // Cancel any previously running loop and reset timing
+  loopId++;
+  const myId = loopId;
+  lastTime = null;
+
   function loop(now) {
+    // If a newer loop was started, stop this one
+    if (myId !== loopId) return;
+
     if (!lastTime) lastTime = now;
     const dtMs = now - lastTime;
     lastTime = now;
 
-    // physics expects seconds; timers use ms
-    const dt = dtMs / 1000;
+    // Cap dt to avoid huge jumps (e.g. after tab was inactive)
+    const dt = Math.min(dtMs / 1000, 0.05);
 
     if (gameState.getMode() === "RUNNING") {
       gameState.update(dtMs);

--- a/src/js/systems/inputs.js
+++ b/src/js/systems/inputs.js
@@ -1,13 +1,19 @@
 import { gameState } from "../core/state.js";
 
 const keys = {};
+let initialized = false;
+
 export function initInput() {
+  if (initialized) return;
+  initialized = true;
+
   window.addEventListener("keydown", (e) => {
     if (e.code === "Space") {
-      // toggle run/pause
-      gameState.setMode(
-        gameState.getMode() === "RUNNING" ? "PAUSED" : "RUNNING",
-      );
+      const mode = gameState.getMode();
+      // Only toggle pause when game is already running or paused
+      if (mode === "RUNNING" || mode === "PAUSED") {
+        gameState.setMode(mode === "RUNNING" ? "PAUSED" : "RUNNING");
+      }
     }
   });
 


### PR DESCRIPTION
closes #7 

During the initialization of each subsequent games, there where multiple game loops and event listeners stacking.
This made it so that after the first game, there where some really erratic behavours such as:

1) Pausing/Resuming the game typically freezed it, since there where multiple event listeners that got fired off  after pressing spacebar and they where fighting each other.
2) Multiple game loops resulted in the ball piercing through 1 health bricks and 2 health bricks got one shotted.
3) Restarting a game after initializing a new game loop, resulted in chaotic ball physics, this had mainly to do with not reseting the lastTime module-level variable, which resulted in too big dt values.

Changes:

1) Flags for event listeners, upon first-time triggering, flags become true, each subsequent triggers always check for those flags and triggering the event only if the flag is not active.
2) Added a unique identifier for each game loop, once a game loop is initialized, increments the loop variable that just holds the overall number of loops triggered, the current loop it gets an identifier thats the same as the overall number of loops, then it checks if those two are the same, and continues on. So if a second game loop[ starts, the overall gameloop variable would be set at 2, the first loop that was running before, has the identifier of 1..so after checking for equality, game loop 1 will stop running, the second loop has the identifier 2, after checking for equality, this loop continues on.
3) Reset lastTime after initializing a game loop.